### PR TITLE
Revert "Update spec_helper.rb to load deps with Bundler"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
-require "bundler"
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 
-Bundler.require
+require "rspec"
+require "i18n-spec"
 
-Dir[File.expand_path("../support/**/*.rb", __FILE__)].each {|f| require f }
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}


### PR DESCRIPTION
This reverts commit 969e3dac4d5243823966f8300e30b85340fbbad9 and fix #4.

The build failed as mentioned in #4 because `Bundler.require` doesn't require development dependencies, otherwise we should write something like `Bundler.require(:default, :development)`.

I think though it's better to explicitly require the necessary dependencies. We can also get the rid of Bundler from dev dependencies btw...

And since we use `bundle exec`, the `$LOAD_PATH` is cleaned up by Bundler (equivalent to `require "bundler/setup"`.