### PR TITLE
Fix duplicated phrases in ja.yml.

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -10,5 +10,5 @@ ja:
       content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
       rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
       mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
-      min_size_error: "ファイルを%{min_size}バイト以上のサイズにしてください"
-      max_size_error: "ファイルを%{max_size}バイト以下のサイズにしてください"
+      min_size_error: "を%{min_size}以上のサイズにしてください"
+      max_size_error: "を%{max_size}以下のサイズにしてください"


### PR DESCRIPTION
Hi, there.

I found wrong traslation. and fixed it.
if you preffered it, Merge this PR! thx. 😃


-----

in your `application_uploader.rb`
```
class ApplicationUploader < CarrierWave::Uploader::Base
  def size_range
    1..10.megabytes
  end
end
```

and, your AR model attributes has i18n like `ファイル`.

`ja.yml`
```
ja:
  activerecord:
    attributes:
      yourmodel:
        file: ファイル
```

error message is 

```
ファイルファイルを1バイトバイト以上のサイズにしてください
```

there is some wrong translation. I think...

`ファイルファイル` should be `ファイル`
`バイトバイト` should be `バイト`

then, I fixed it.
