### PR TITLE
Add allowed_types to content_type_whitelist_error

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -6,7 +6,7 @@ ja:
       carrierwave_download_error: はダウンロードできません
       extension_whitelist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
       extension_blacklist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
-      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
       content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
       rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
       mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"


### PR DESCRIPTION
Add `allowed_types` to `content_type_whitelist_error` since [1.3.0](https://github.com/carrierwaveuploader/carrierwave/blob/a91ab69fdd8052cdf5a5e48ef8baf40939e441fb/CHANGELOG.md#130---2018-12-24).