### PR TITLE
Include `allowed_types` in pt-BR translation

### DIFF
--- a/rails/locales/pt-BR.yml
+++ b/rails/locales/pt-BR.yml
@@ -6,7 +6,7 @@ pt-BR:
       carrierwave_download_error: não pôde ser baixado
       extension_whitelist_error: "Não é permitido o envio de arquivos %{extension}, tipos permitidos: %{allowed_types}"
       extension_blacklist_error: "Não é permitido o envio de arquivos %{extension}, tipos proibidos: %{prohibited_types}"
-      content_type_whitelist_error: "Não é permitido o envio de arquivos %{content_type}"
+      content_type_whitelist_error: "Não é permitido o envio de arquivos %{content_type}, tipos permitidos: %{allowed_types}"
       content_type_blacklist_error: "Não é permitido o envio de arquivos %{content_type}"
       rmagick_processing_error: "Falha ao manipular com RMagick, talvez arquivo não seja uma imagem? Erro original: %{e}"
       mini_magick_processing_error: "Falha ao manipular com MiniMagick, talvez arquivo não seja uma imagem? Erro original: %{e}"


### PR DESCRIPTION
Before this commit, the `pt-BR` translation file was not including the `allowed_types` array inside the `content_type_whitelist_error` error message.
I believe that by including the `allowed_types` in the error message we give better feedback to the user - i.e. the user will know just by looking at the error message which type of files they can upload.

I noticed the `allowed_types` are included in [Carrierwave's README](https://github.com/carrierwaveuploader/carrierwave#i18n) but when I came here to get the `pt-BR` translation the `allowed_types` were missing, so I decided to write this patch for it.

Please let me know what you think.