### PR TITLE
improve zh-TW / zh-CN characters readability

### DIFF
--- a/rails/locales/zh-CN.yml
+++ b/rails/locales/zh-CN.yml
@@ -4,11 +4,11 @@ zh-CN:
       carrierwave_processing_error: 处理错误
       carrierwave_integrity_error: 文件类型不正确
       carrierwave_download_error: 下载错误
-      extension_whitelist_error: "不可上传 %{extension} 文件, 可上传文件类型为: %{allowed_types}"
-      extension_blacklist_error: "不可上传 %{extension} 文件, 不可上传文件类型为: %{prohibited_types}"
+      extension_whitelist_error: "不可上传 %{extension} 文件，可上传文件类型为：%{allowed_types}"
+      extension_blacklist_error: "不可上传 %{extension} 文件，不可上传文件类型为：%{prohibited_types}"
       content_type_whitelist_error: "不可上传 %{content_type} 文件"
       content_type_blacklist_error: "不可上传 %{content_type} 文件"
-      rmagick_processing_error: "rmagick 错误, 也许上传的文件不是图片? 原错误: %{e}"
-      mini_magick_processing_error: "MiniMagick 错误, 也许上传的文件不是图片? 原错误: %{e}"
+      rmagick_processing_error: "rmagick 错误，也许上传的文件不是图片? 原错误：%{e}"
+      mini_magick_processing_error: "MiniMagick 错误，也许上传的文件不是图片? 原错误：%{e}"
       min_size_error: "文件大小应大于 %{min_size}"
       max_size_error: "文件的大小应小于 %{max_size}"

--- a/rails/locales/zh-TW.yml
+++ b/rails/locales/zh-TW.yml
@@ -4,11 +4,11 @@ zh-TW:
       carrierwave_processing_error: 處理錯誤
       carrierwave_integrity_error: 文件類型錯誤
       carrierwave_download_error: 下載錯誤
-      extension_whitelist_error: "不可上傳 %{extension} 文件, 可上傳文件類型為: %{allowed_types}"
-      extension_blacklist_error: "不可上傳 %{extension} 文件, 不可上傳文件類型為: %{prohibited_types}"
+      extension_whitelist_error: "不可上傳 %{extension} 文件，可上傳文件類型為：%{allowed_types}"
+      extension_blacklist_error: "不可上傳 %{extension} 文件，不可上傳文件類型為：%{prohibited_types}"
       content_type_whitelist_error: "不可上傳 %{content_type} 文件"
       content_type_blacklist_error: "不可上傳 %{content_type} 文件"
-      rmagick_processing_error: "rmagick 錯誤, 也許上傳的的文件不是圖片? 原錯誤: %{e}"
-      mini_magick_processing_error: "MiniMagick 錯誤, 也許上傳的文件不是圖片? 原錯誤: %{e}"
+      rmagick_processing_error: "rmagick 錯誤，也許上傳的的文件不是圖片？原錯誤：%{e}"
+      mini_magick_processing_error: "MiniMagick 錯誤，也許上傳的文件不是圖片？原錯誤：%{e}"
       min_size_error: "文件大小應大於 %{min_size}"
       max_size_error: "文件大小應小於 %{max_size}"


### PR DESCRIPTION
> For aesthetic reasons and readability, it is preferable for Han characters to be approximately square-shaped.

https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms#Rationale