### PR TITLE
German translation: improve wording, spelling and avoid context sensitive german pronouns

### DIFF
--- a/rails/locales/de.yml
+++ b/rails/locales/de.yml
@@ -1,14 +1,14 @@
 de:
   errors:
     messages:
-      carrierwave_processing_error: konnte nicht verarbeitet werden
-      carrierwave_integrity_error: ist kein erlaubter Dateityp
-      carrierwave_download_error: konnte nicht heruntergeladen werden
-      extension_whitelist_error: "Sie sind nicht berechtigt %{extension} Dateien hochzuladen, erlaubte Typen: %{allowed_types}"
-      extension_blacklist_error: "Sie sind nicht berechtigt %{extension} Dateien hochzuladen, verbotene Typen: %{prohibited_types}"
-      content_type_whitelist_error: "Sie sind nicht berechtigt %{content_type} Dateien hochzuladen"
-      content_type_blacklist_error: "Sie sind nicht berechtigt %{content_type} Dateien hochzuladen"
-      rmagick_processing_error: "Verarbeitung mit rmagick fehlgeschlagen, vielleicht ist es kein Bild? Original Fehler: %{e}"
-      mini_magick_processing_error: "Verarbeitung mit MiniMagick fehlgeschlagen, vielleicht ist es kein Bild? Original Fehler: %{e}"
-      min_size_error: "Die dateigröße sollte größer sein als %{min_size}"
-      max_size_error: "Die dateigröße sollte weniger als sein %{max_size}"
+      carrierwave_processing_error: "konnte nicht verarbeitet werden"
+      carrierwave_integrity_error: "ist kein erlaubter Dateityp"
+      carrierwave_download_error: "konnte nicht heruntergeladen werden"
+      extension_whitelist_error: "Dateityp %{extension} ist für den Upload nicht zulässig. Erlaubte Dateitypen: %{allowed_types}"
+      extension_blacklist_error: "Dateityp %{extension} ist für den Upload nicht zulässig. Verbotene Dateitypen: %{prohibited_types}"
+      content_type_whitelist_error: "Dateityp %{extension} ist für den Upload nicht zulässig"
+      content_type_blacklist_error: "Dateityp %{extension} ist für den Upload nicht zulässig"
+      rmagick_processing_error: "Verarbeitung mit rmagick fehlgeschlagen, vielleicht ist es kein Bild? Ursprünglicher Fehler: %{e}"
+      mini_magick_processing_error: "Verarbeitung mit MiniMagick fehlgeschlagen, vielleicht ist es kein Bild? Ursprünglicher Fehler: %{e}"
+      min_size_error: "Die Dateigröße muss größer als %{min_size} sein"
+      max_size_error: "Die Dateigröße muss kleiner als %{max_size} sein"


### PR DESCRIPTION
This PR affects only the German translation:

- Word order, spelling
- Changed the wording for `extension_` and `content_type_` errors to avoid German pronouns (*Sie* and *Du*) completely because they are [context sensitive (formal, informal)](https://en.wikipedia.org/wiki/T%E2%80%93V_distinction#German)

I also added double quotes to first three strings. Is this okay?

Edit: this is the PR I mentioned regarding my question in issue #23 